### PR TITLE
Write to PVC in parsl run script

### DIFF
--- a/run.py
+++ b/run.py
@@ -63,6 +63,8 @@ def get_parsl_config():
                     init_blocks=1,
                     # Maximum number of pods to scale up
                     max_blocks=1,
+                    # list of tuples w/ the format: (PVC Name, Mount Directory)
+                    persistent_volumes=[("qgnet-pvc-test-1", "/data")],
                 ),
             ),
         ]
@@ -105,7 +107,7 @@ if __name__ == "__main__":
         print(f"Random number: {random.result()}")
 
         # Save the random number to a file
-        output_path = "sequential-output.txt"
+        output_path = "/data/sequential-output.txt"
         saved = save_value_to_file(
             value=random,
             output_filepath=File(output_path),


### PR DESCRIPTION
Maybe next step is using envvars to remove the `/data` magic string? Right now both our script and our YAML needs to know about it, but ideally only our YAML should need to know about the actual dirname, and use an envvar to tell the script. The actual dir is a deployment detail.