### PR TITLE
Deps for runner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM mambaorg/micromamba:1.5.8 AS micromamba
 
 USER root
-RUN apt update && apt install -y git
+RUN apt update && apt install -y git wget
 USER $MAMBA_USER
 
 COPY --chown=$MAMBA_USER:$MAMBA_USER . .

--- a/environment.yml
+++ b/environment.yml
@@ -8,10 +8,11 @@ dependencies:
   # dependency specification problem:
   #     https://github.com/conda-forge/parsl-feedstock/pull/72
   - parsl-with-kubernetes ~=2024.4,>=2014.4.15
+  - gdal
 
   # We forked Parsl to get around this issue:
   #     https://github.com/Parsl/parsl/pull/3357
   # TODO: Once the PR above is merged, ensure built for conda-forge and move
   #       parsl back out of the pip section
   - pip:
-      - "--editable=git+https://github.com/QGreenland-Net/parsl.git@k8s-use-incluser-config-fallback#egg=parsl"
+      - "--editable=git+https://github.com/trey-stafford/parsl.git@k8s-use-incluser-config-fallback#egg=parsl"


### PR DESCRIPTION
Updated deps for the `odgc-runner`.

We should transfer management of this docker image to the `ogdc-runner` repo. This is mostly just to take advantage of the existing GHA to test a couple of changes quickly...tagged v0.2.0.

It may also make sense to have a "worker" image that has all of the deps workers need (e.g., `gdal`) rather than using one image for both the parsl init script & its workers. That could be defined in `ogdc-recipes`?